### PR TITLE
feat: google sign v7

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -104,14 +104,12 @@
 
     <!-- Google frameworks -->
     <preference name="GOOGLE_SIGN_IN_VERSION" default="~> 7.0.0"/>
-    <preference name="GOOGLE_UTILITIES_VERSION" default="~> 7.13.3"/>
     <podspec>
       <config>
         <source url="https://cdn.cocoapods.org/"/>
       </config>
       <pods use-frameworks="true">
         <pod name="GoogleSignIn" spec="$GOOGLE_SIGN_IN_VERSION"/>
-        <pod name="GoogleUtilities" spec="$GOOGLE_UTILITIES_VERSION"/>
       </pods>
     </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -104,7 +104,7 @@
 
     <!-- Google frameworks -->
     <preference name="GOOGLE_SIGN_IN_VERSION" default="~> 6.2.4"/>
-    <preference name="GOOGLE_UTILITIES_VERSION" default="~> 7.13.0"/>
+    <preference name="GOOGLE_UTILITIES_VERSION" default="~> 7.13.3"/>
     <podspec>
       <config>
         <source url="https://cdn.cocoapods.org/"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -103,7 +103,7 @@
     <framework src="libz.dylib" weak="true" />
 
     <!-- Google frameworks -->
-    <preference name="GOOGLE_SIGN_IN_VERSION" default="~> 6.2.4"/>
+    <preference name="GOOGLE_SIGN_IN_VERSION" default="~> 7.0.0"/>
     <preference name="GOOGLE_UTILITIES_VERSION" default="~> 7.13.3"/>
     <podspec>
       <config>

--- a/src/ios/GooglePlus.h
+++ b/src/ios/GooglePlus.h
@@ -5,6 +5,7 @@
 
 @property (nonatomic, copy) NSString* callbackId;
 @property (nonatomic, assign) BOOL isSigningIn;
+@property (nonatomic, copy) NSString* serverAuthCode;
 
 - (void) isAvailable:(CDVInvokedUrlCommand*)command;
 - (void) login:(CDVInvokedUrlCommand*)command;

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -62,22 +62,16 @@
     GIDSignIn *signIn = [GIDSignIn sharedInstance];
     signIn.configuration = config;
 
-    [signIn signInWithPresentingViewController:self.viewController hint:nil completion:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
-        if (user && hasAdditionalScopes) {
-            [user addScopes:scopesArray presentingViewController:self.viewController completion:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
-                [self handleSignInCompleteWithUser:user error:error];
-            }];
-        } else {
-            [self handleSignInCompleteWithUser:user error:error];
-        }
+    [signIn signInWithPresentingViewController:self.viewController hint:nil additionalScopes:scopesArray completion:^(GIDSignInResult * _Nullable signInResult, NSError * _Nullable error) {
+        [self handleSignInCompleteWithUser:signInResult.user error:error];
     }];
 }
 
 - (void) trySilentLogin:(CDVInvokedUrlCommand*)command {
     _callbackId = command.callbackId;
     GIDSignIn *signIn = [GIDSignIn sharedInstance];
-    [signIn restorePreviousSignInWithCallback:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
-        [self handleSignInCompleteWithUser:user error:error];
+    [signIn restorePreviousSignInWithCompletion:^(GIDSignInResult * _Nullable signInResult, NSError * _Nullable error) {
+        [self handleSignInCompleteWithUser:signInResult.user error:error];
     }];
 }
 
@@ -91,7 +85,7 @@
         NSString *accessToken = user.accessToken.tokenString;
         NSString *refreshToken = user.refreshToken.tokenString;
         NSString *userId = user.userID;
-        NSString *serverAuthCode = user.serverAuthCode != nil ? user.serverAuthCode : @"";
+        NSString *serverAuthCode = user.serverAuthCode.length > 0 ? user.serverAuthCode : @"";
         NSURL *imageUrl = [user.profile imageURLWithDimension:120]; // TODO pass in img size as param, and try to sync with Android
         NSDictionary *result = @{
                        @"email"           : email,
@@ -143,7 +137,7 @@
 
 - (void) disconnect:(CDVInvokedUrlCommand*)command {
     GIDSignIn *signIn = [GIDSignIn sharedInstance];
-    [signIn disconnectWithCallback:^(NSError * _Nullable error) {
+    [signIn disconnectWithCompletion:^(NSError * _Nullable error) {
         CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"disconnected"];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -64,8 +64,10 @@
 
     [signIn signInWithPresentingViewController:self.viewController hint:nil additionalScopes:scopesArray completion:^(GIDSignInResult * _Nullable signInResult, NSError * _Nullable error) {
         if (signInResult && signInResult.serverAuthCode) {
-            // Store server auth code if available
             self.serverAuthCode = signInResult.serverAuthCode;
+        }
+        else {
+            self.serverAuthCode = @"";
         }
         [self handleSignInCompleteWithUser:signInResult.user error:error];
     }];

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -70,8 +70,8 @@
 - (void) trySilentLogin:(CDVInvokedUrlCommand*)command {
     _callbackId = command.callbackId;
     GIDSignIn *signIn = [GIDSignIn sharedInstance];
-    [signIn restorePreviousSignInWithCompletion:^(GIDSignInResult * _Nullable signInResult, NSError * _Nullable error) {
-        [self handleSignInCompleteWithUser:signInResult.user error:error];
+    [signIn restorePreviousSignInWithCompletion:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
+        [self handleSignInCompleteWithUser:user error:error];
     }];
 }
 
@@ -85,7 +85,7 @@
         NSString *accessToken = user.accessToken.tokenString;
         NSString *refreshToken = user.refreshToken.tokenString;
         NSString *userId = user.userID;
-        NSString *serverAuthCode = user.serverAuthCode.length > 0 ? user.serverAuthCode : @"";
+        NSString *serverAuthCode = user.serverAuthCode != nil ? user.serverAuthCode : @"";
         NSURL *imageUrl = [user.profile imageURLWithDimension:120]; // TODO pass in img size as param, and try to sync with Android
         NSDictionary *result = @{
                        @"email"           : email,

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -63,6 +63,10 @@
     signIn.configuration = config;
 
     [signIn signInWithPresentingViewController:self.viewController hint:nil additionalScopes:scopesArray completion:^(GIDSignInResult * _Nullable signInResult, NSError * _Nullable error) {
+        if (signInResult && signInResult.serverAuthCode) {
+            // Store server auth code if available
+            self.serverAuthCode = signInResult.serverAuthCode;
+        }
         [self handleSignInCompleteWithUser:signInResult.user error:error];
     }];
 }
@@ -85,7 +89,7 @@
         NSString *accessToken = user.accessToken.tokenString;
         NSString *refreshToken = user.refreshToken.tokenString;
         NSString *userId = user.userID;
-        NSString *serverAuthCode = user.serverAuthCode != nil ? user.serverAuthCode : @"";
+        NSString *serverAuthCode = self.serverAuthCode ? self.serverAuthCode : @"";
         NSURL *imageUrl = [user.profile imageURLWithDimension:120]; // TODO pass in img size as param, and try to sync with Android
         NSDictionary *result = @{
                        @"email"           : email,

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -60,9 +60,16 @@
     GIDConfiguration *config = [[GIDConfiguration alloc] initWithClientID:clientId serverClientID:serverClientId hostedDomain:hostedDomain openIDRealm:nil];
 
     GIDSignIn *signIn = [GIDSignIn sharedInstance];
+    signIn.configuration = config;
 
-    [signIn signInWithConfiguration:config presentingViewController:self.viewController hint:nil additionalScopes:scopesArray callback:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
-      [self handleSignInCompleteWithUser:user error:error];
+    [signIn signInWithPresentingViewController:self.viewController hint:nil completion:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
+        if (user && hasAdditionalScopes) {
+            [user addScopes:scopesArray presentingViewController:self.viewController completion:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
+                [self handleSignInCompleteWithUser:user error:error];
+            }];
+        } else {
+            [self handleSignInCompleteWithUser:user error:error];
+        }
     }];
 }
 
@@ -80,9 +87,9 @@
         [self.commandDelegate sendPluginResult:pluginResult callbackId:_callbackId];
     } else {
         NSString *email = user.profile.email;
-        NSString *idToken = user.authentication.idToken;
-        NSString *accessToken = user.authentication.accessToken;
-        NSString *refreshToken = user.authentication.refreshToken;
+        NSString *idToken = user.idToken.tokenString;
+        NSString *accessToken = user.accessToken.tokenString;
+        NSString *refreshToken = user.refreshToken.tokenString;
         NSString *userId = user.userID;
         NSString *serverAuthCode = user.serverAuthCode != nil ? user.serverAuthCode : @"";
         NSURL *imageUrl = [user.profile imageURLWithDimension:120]; // TODO pass in img size as param, and try to sync with Android


### PR DESCRIPTION
Code change between GoogleSignIn 6 and 7
https://github.com/google/GoogleSignIn-iOS/compare/6.2.4...7.0.0

Changelog 7.0.0: https://github.com/google/GoogleSignIn-iOS/blob/main/CHANGELOG.md#700

Version 7.0.0 especifically because it's the version used by firebasex.

- GoogleUtilities is no longer needed since GoogleSignIn 4 was removed.
- Based on the code diff: signInWithConfiguration was changed for signInWithPresentingViewController, and the usage was accommodated.
- Changes from GIDGoogleUser => GIDSignInResult
- authentication object is no longer available and was adapted (as seen in changelog)
- Callback => Completation
- serverAuthCode is no longer available the way it was before, context variable was added and accessed on handleSignInCompleteWithUser that way.

Everything seems to be working.